### PR TITLE
Remove double selector to avoid double font-size application

### DIFF
--- a/css/Harlowe.css
+++ b/css/Harlowe.css
@@ -40,7 +40,7 @@
 @import url('https://fonts.googleapis.com/css?family=PT+Sans+Caption:400,700');
 
 /* These are the default options for the entire browser window */
-body, tw-story {	
+tw-story {	
 	background-color: #002b36; 
 	/* Color is the foreground / font color */
 	color: #839496;

--- a/css/Harlowe.css
+++ b/css/Harlowe.css
@@ -47,7 +47,7 @@ tw-story {
 	/* Make sure the first font listed is one of the fonts you imported above */
 	font-family: 'PT Sans Caption', sans-serif;
 	/* This makes the font size for normal letters just a little bit bigger than default */
-	font-size: 1.1em;
+	font-size: 1.25em;
 }
 
 /* These are the default options for the each passage area */


### PR DESCRIPTION
Reddit user /u/bagera_se pointed out that the selector combo `body, tw-story` applies the font rule twice, leading to a too-large font size.